### PR TITLE
Handle custom assembly names during test setup

### DIFF
--- a/tests/Initialize-TestEnvironment.Tests.ps1
+++ b/tests/Initialize-TestEnvironment.Tests.ps1
@@ -1,0 +1,7 @@
+Describe 'Initialize-TestEnvironment' {
+  It 'imports module with custom assembly name' {
+    . $PSScriptRoot/Shared.ps1
+    { Initialize-TestEnvironment -ProjectName 'Example.3.CSharp' } | Should -Not -Throw
+    Get-Command Get-PEURandomLetter | Should -Not -BeNullOrEmpty
+  }
+}

--- a/tests/Shared.ps1
+++ b/tests/Shared.ps1
@@ -2,9 +2,15 @@ function Initialize-TestEnvironment ($ProjectName) {
   $ErrorActionPreference = 'Stop'
   $ProjectPath = Resolve-Path (Join-Path $PSScriptRoot "../src/$ProjectName")
   $PublishPath = Join-Path $ProjectPath 'bin/Debug/net6.0/publish'
-  if (-not (Test-Path "$ProjectPath/$ProjectName.csproj")) {
+  $ProjectFile = Join-Path $ProjectPath "$ProjectName.csproj"
+  if (-not (Test-Path $ProjectFile)) {
     throw [NotImplementedException]"This lab has not been initialized yet. Hint: (dotnet new classlib -o $ProjectPath) then copy the contents of Example.1.PowerShell.csproj to $ProjectPath/$ProjectName.csproj."
   }
+
+  [xml]$ProjectXml = Get-Content $ProjectFile
+  $AssemblyName = $ProjectXml.Project.PropertyGroup.AssemblyName
+  if (-not $AssemblyName) { $AssemblyName = $ProjectName }
+
   $PackageList = dotnet list $ProjectPath package
   if (-not $PackageList -match 'System.Management.Automation.*7.2') {
     throw [NotImplementedException]"This lab has does not have the System.Management.Automation v7.2 package added for PowerShell module development. Hint: dotnet add $ProjectPath package System.Management.Automation --version 7.2.11"
@@ -13,5 +19,5 @@ function Initialize-TestEnvironment ($ProjectName) {
     throw [NotImplementedException]"This lab does not have the Lorem Universal package added. Hint: dotnet add $ProjectPath package Lorem.Universal.Net"
   }
   & dotnet publish $ProjectPath
-  Import-Module (Join-Path $PublishPath "$ProjectName.dll")
+  Import-Module (Join-Path $PublishPath "$AssemblyName.dll")
 }


### PR DESCRIPTION
## Summary
- resolve module assembly name dynamically when initializing test environment
- add Pester test ensuring initialization works with custom assembly names

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester tests/Initialize-TestEnvironment.Tests.ps1" -EA Stop` *(fails: command not found: pwsh)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_689c00a1c128832b893b16dae79f0bb9